### PR TITLE
[FIX/#12] 안드로이드 하단 탭바에서 아이콘 깨지는 문제 수정

### DIFF
--- a/e-eum/Sources/E_Eum/View/ContentView.swift
+++ b/e-eum/Sources/E_Eum/View/ContentView.swift
@@ -11,11 +11,19 @@ struct ContentView: View {
     var body: some View {
         TabView(selection: $tab) {
             InfoView()
-                .tabItem { Label("띵동", systemImage: "house.fill") }
+                .tabItem {
+                    Label("띵동", systemImage: "house")
+                }
                 .tag(ContentTab.info)
             
             PlaceView()
-                .tabItem { Label("지도", systemImage: "map.fill") }
+                .tabItem {
+                    #if SKIP
+                    Label("장소", systemImage: "Icons.Outlined.Place")
+                    #else
+                    Label("장소", systemImage: "mappin.and.ellipse")
+                    #endif
+                }
                 .tag(ContentTab.place)
         }
         .preferredColorScheme(.light)


### PR DESCRIPTION
#️⃣ Issue Number

#12 

✍️ Memo

안드로이드에 아이콘이 존재하지 않아서 깨지는 부분은 전처리문을 통해서 iOS와 안드로이드의 코드 분리
